### PR TITLE
Added support for personal tokens DEVRL-440

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  test:
+  service-token-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,3 +15,17 @@ jobs:
         env:
           NODE_ENV: development
           DOPPLER_TOKEN: ${{ secrets.TEST_DOPPLER_TOKEN }}
+  personal-token-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm run test
+        env:
+          NODE_ENV: development
+          DOPPLER_TOKEN: ${{ secrets.TEST_DOPPLER_PERSONAL_TOKEN }}
+          DOPPLER_PROJECT: github-actions-secrets-fetch-test
+          DOPPLER_CONFIG: prd

--- a/README.md
+++ b/README.md
@@ -6,9 +6,38 @@ This action enables you to fetch Doppler secrets for use in your GitHub Actions.
 
 ## Configuration
 
-This action requires a [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) to provide read-only access to secrets for a specific Config within a [Project](https://docs.doppler.com/docs/create-project).
+The action can be configured in two ways:
+
+* Service Token (recommended)
+* Personal Token with Project and Config
+
+### Service Token
+
+A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to single config and is recommended due to its limited access scope.
 
 Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Service Tokens (e.g. for a Monorepo), you can prefix the secret name using with application name, e.g. `AUTH_API_DOPPLER_TOKEN`.
+
+Then supply the Service Token using the `doppler-token` input:
+
+```yaml
+- uses: dopplerhq/secrets-fetch-action@v1.1.0
+      id: doppler
+      with:
+        doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+```
+
+### Personal Token
+
+A Doppler Personal Token provides read/write access to every Project and Config accessible for that account and should only be used when necessary. The `doppler-project` and `doppler-config` inputs must be provided when using a Personal Token:
+
+```yaml
+- uses: dopplerhq/secrets-fetch-action@v1.1.0
+      id: doppler
+      with:
+        doppler-token: ${{ secrets.PERSONAL_DOPPLER_TOKEN }}
+        project: auth-api
+        config: ci-cd
+```
 
 ## Usage
 
@@ -30,7 +59,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: doppleruniversity/secrets-fetch-action@v1
+    - uses: dopplerhq/secrets-fetch-action@v1.1.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -53,7 +82,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: doppleruniversity/secrets-fetch-action@v0.0.1
+    - uses: dopplerhq/secrets-fetch-action@v1.1.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -68,3 +97,7 @@ All secret values are masked with the exception of the Doppler meta variables:
 - `DOPPLER_PROJECT`
 - `DOPPLER_ENVIRONMENT`
 - `DOPPLER_CONFIG`
+
+# Development and Testing
+
+Export the `NODE_ENV` and `DOPPLER_TOKEN` environment variables, then run `npm test`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The action can be configured in two ways:
 
 ### Service Token
 
-A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to single config and is recommended due to its limited access scope.
+A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to a single config and is recommended due to its limited access scope.
 
 Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Service Tokens (e.g. for a Monorepo), you can prefix the secret name using with application name, e.g. `AUTH_API_DOPPLER_TOKEN`.
 
@@ -35,8 +35,8 @@ A Doppler Personal Token provides read/write access to every Project and Config 
       id: doppler
       with:
         doppler-token: ${{ secrets.PERSONAL_DOPPLER_TOKEN }}
-        project: auth-api
-        config: ci-cd
+        doppler-project: auth-api
+        doppler-config: ci-cd
 ```
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
       Doppler Service Token that grants access to a single Config within a Project. 
       See https://docs.doppler.com/docs/service-tokens
     required: true
+  doppler-project:
+    description: >-
+      Doppler Project
+    required: false
+  doppler-config:
+    description: >-
+      Doppler Config slug (e.g. prd)
+    required: false
   inject-env-vars:
     description: >-
       Inject secrets as environment variables for subsequent steps if set to `true`.

--- a/doppler.js
+++ b/doppler.js
@@ -1,19 +1,29 @@
+import { setCommandEcho } from "@actions/core";
 import https from "https";
-import { VERSION } from './meta.js'
+import { VERSION } from "./meta.js";
 
 /**
- * Fetch secrets from Doppler the API.
- * Requires the `DOPPLER_TOKEN` environment variable to be set. See https://docs.doppler.com/docs/enclave-service-tokens
+ * Fetch secrets from Doppler the API
+ * @param {string} dopplerToken
+ * @param {string} [dopplerProject]
+ * @param {string} [dopplerConfig]
  * @returns {() => Promise<Record<string, string>>}
  */
-async function fetch(dopplerToken) {
+async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
   return new Promise(function (resolve, reject) {
     const encodedAuthData = Buffer.from(`${dopplerToken}:`).toString("base64");
     const authHeader = `Basic ${encodedAuthData}`;
     const userAgent = `secrets-fetch-github-action/${VERSION}`;
+
+    const url = new URL("https://api.doppler.com/v3/configs/config/secrets/download?format=json");
+    if (dopplerProject && dopplerConfig) {
+      url.searchParams.append("project", dopplerProject);
+      url.searchParams.append("config", dopplerConfig);
+    }
+
     https
       .get(
-        "https://api.doppler.com/v3/configs/config/secrets/download?format=json",
+        url.href,
         {
           headers: {
             Authorization: authHeader,
@@ -44,5 +54,4 @@ async function fetch(dopplerToken) {
   });
 }
 
-export default fetch
-
+export default fetch;

--- a/doppler.js
+++ b/doppler.js
@@ -1,12 +1,11 @@
-import { setCommandEcho } from "@actions/core";
 import https from "https";
 import { VERSION } from "./meta.js";
 
 /**
  * Fetch secrets from Doppler the API
  * @param {string} dopplerToken
- * @param {string} [dopplerProject]
- * @param {string} [dopplerConfig]
+ * @param {string | null} [dopplerProject]
+ * @param {string | null} [dopplerConfig]
  * @returns {() => Promise<Record<string, string>>}
  */
 async function fetch(dopplerToken, dopplerProject, dopplerConfig) {

--- a/index.js
+++ b/index.js
@@ -9,17 +9,16 @@ if (process.env.NODE_ENV === "development" && process.env.DOPPLER_TOKEN) {
 }
 
 const DOPPLER_META = ["DOPPLER_PROJECT", "DOPPLER_CONFIG", "DOPPLER_ENVIRONMENT"];
-
 const DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 core.setSecret(DOPPLER_TOKEN);
 
-// Project and Config are required if a Personal token supplied
 const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.startsWith("dp.pt.");
-if (IS_PERSONAL_TOKEN) {
-  console.log("[info]: Personal token detected. doppler-project and doppler-config inputs are now required.");
+const DOPPLER_PROJECT = IS_PERSONAL_TOKEN ? core.getInput("doppler-project") : null;
+const DOPPLER_CONFIG = IS_PERSONAL_TOKEN ? core.getInput("doppler-config") : null;
+if (IS_PERSONAL_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
+  core.setFailed("doppler-project and doppler-config inputs are required when using a Personal token");
+  process.exit();
 }
-const DOPPLER_PROJECT = IS_PERSONAL_TOKEN ? core.getInput("doppler-project", { required: true }) : null;
-const DOPPLER_CONFIG = IS_PERSONAL_TOKEN ? core.getInput("doppler-config", { required: true }) : null;
 
 const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 

--- a/index.js
+++ b/index.js
@@ -4,18 +4,24 @@ import fetch from "./doppler.js";
 // For local testing
 if (process.env.NODE_ENV === "development" && process.env.DOPPLER_TOKEN) {
   process.env["INPUT_DOPPLER-TOKEN"] = process.env.DOPPLER_TOKEN;
+  process.env["INPUT_DOPPLER-PROJECT"] = process.env.DOPPLER_PROJECT;
+  process.env["INPUT_DOPPLER-CONFIG"] = process.env.DOPPLER_CONFIG;
 }
 
-const DOPPLER_META = [
-  "DOPPLER_PROJECT",
-  "DOPPLER_CONFIG",
-  "DOPPLER_ENVIRONMENT",
-];
+const DOPPLER_META = ["DOPPLER_PROJECT", "DOPPLER_CONFIG", "DOPPLER_ENVIRONMENT"];
 
 const DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 core.setSecret(DOPPLER_TOKEN);
 
-const secrets = await fetch(DOPPLER_TOKEN);
+// Project and Config are required if a Personal token supplied
+const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.indexOf("dp.pt") >= 0;
+if (IS_PERSONAL_TOKEN) {
+  console.log("[info]: Personal token detected. doppler-project and doppler-config inputs are now required.");
+}
+const DOPPLER_PROJECT = IS_PERSONAL_TOKEN ? core.getInput("doppler-project", { required: true }) : null;
+const DOPPLER_CONFIG = IS_PERSONAL_TOKEN ? core.getInput("doppler-config", { required: true }) : null;
+
+const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 
 for (const [key, value] of Object.entries(secrets)) {
   core.setOutput(key, value);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 core.setSecret(DOPPLER_TOKEN);
 
 // Project and Config are required if a Personal token supplied
-const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.indexOf("dp.pt") >= 0;
+const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.startsWith("dp.pt.");
 if (IS_PERSONAL_TOKEN) {
   console.log("[info]: Personal token detected. doppler-project and doppler-config inputs are now required.");
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "GitHub Action to fetch secrets from Doppler's API",
     "author": "Doppler",
     "license": "Apache-2.0",
     "bugs": {
-        "url": "https://github.com/DopplerUniversity/secrets-fetch-action/issues"
+        "url": "https://github.com/dopplerhq/secrets-fetch-action/issues"
     },
     "main": "index.js",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/DopplerUniversity/secrets-fetch-action"
+        "url": "git+https://github.com/dopplerhq/secrets-fetch-action"
     },
     "type": "module",
     "scripts": {
         "test": "node index.js"
     },
     "keywords": [],
-    "homepage": "https://github.com/DopplerUniversity/#readme",
+    "homepage": "https://github.com/dopplerhq/secrets-fetch-action/#readme",
     "dependencies": {
         "@actions/core": "^1.8.0"
     }


### PR DESCRIPTION
Personal tokens are now supported via two new inputs: `doppler-project` and `doppler-config`.

Also fixed various documentation typos.