### PR TITLE
Switch examples from Personal Token to Service Account token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           NODE_ENV: development
           DOPPLER_TOKEN: ${{ secrets.TEST_DOPPLER_TOKEN }}
-  personal-token-test:
+  service-account-token-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +26,6 @@ jobs:
       - run: npm run test
         env:
           NODE_ENV: development
-          DOPPLER_TOKEN: ${{ secrets.TEST_DOPPLER_PERSONAL_TOKEN }}
-          DOPPLER_PROJECT: github-actions-secrets-fetch-test
-          DOPPLER_CONFIG: prd
+          DOPPLER_TOKEN: ${{ secrets.TEST_DOPPLER_SA_TOKEN }}
+          DOPPLER_PROJECT: secrets-fetch-action
+          DOPPLER_CONFIG: test

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action enables you to fetch Doppler secrets for use in your GitHub Actions.
 The action can be configured in two ways:
 
 * Service Token (recommended)
-* Personal Token with Project and Config
+* Service Account Token with Project and Config
 
 ### Service Token
 
@@ -26,15 +26,15 @@ Then supply the Service Token using the `doppler-token` input:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
 ```
 
-### Personal Token
+### Service Account Token
 
-A Doppler Personal Token provides read/write access to every Project and Config accessible for that account and should only be used when necessary. The `doppler-project` and `doppler-config` inputs must be provided when using a Personal Token:
+A Doppler Service Account Token allows for a configurable set of permissions to services in your workplace. The `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Token:
 
 ```yaml
 - uses: dopplerhq/secrets-fetch-action@v1.1.1
       id: doppler
       with:
-        doppler-token: ${{ secrets.PERSONAL_DOPPLER_TOKEN }}
+        doppler-token: ${{ secrets.DOPPLER_TOKEN }}
         doppler-project: auth-api
         doppler-config: ci-cd
 ```

--- a/index.js
+++ b/index.js
@@ -12,11 +12,16 @@ const DOPPLER_META = ["DOPPLER_PROJECT", "DOPPLER_CONFIG", "DOPPLER_ENVIRONMENT"
 const DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 core.setSecret(DOPPLER_TOKEN);
 
+const IS_SA_TOKEN = DOPPLER_TOKEN.startsWith("dp.sa.");
 const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.startsWith("dp.pt.");
-const DOPPLER_PROJECT = IS_PERSONAL_TOKEN ? core.getInput("doppler-project") : null;
-const DOPPLER_CONFIG = IS_PERSONAL_TOKEN ? core.getInput("doppler-config") : null;
+const DOPPLER_PROJECT = (IS_SA_TOKEN || IS_PERSONAL_TOKEN) ? core.getInput("doppler-project") : null;
+const DOPPLER_CONFIG = (IS_SA_TOKEN || IS_PERSONAL_TOKEN) ? core.getInput("doppler-config") : null;
 if (IS_PERSONAL_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
-  core.setFailed("doppler-project and doppler-config inputs are required when using a Personal token");
+  core.setFailed("doppler-project and doppler-config inputs are required when using a Personal token. Additionally, we recommend switching to Service Accounts.");
+  process.exit();
+}
+if (IS_SA_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
+  core.setFailed("doppler-project and doppler-config inputs are required when using a Service Account token");
   process.exit();
 }
 


### PR DESCRIPTION
Using a personal token is inadvisable as it's tied to a user identity. Now that we have Service Account tokens, we can switch all documentation to those.

Closes ENG-6414