### PR TITLE
Use Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install
       - run: npm run test
         env:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install
       - run: npm run test
         env:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Ser
 Then supply the Service Token using the `doppler-token` input:
 
 ```yaml
-- uses: dopplerhq/secrets-fetch-action@v1.1.2
+- uses: dopplerhq/secrets-fetch-action@v1.1.3
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -31,7 +31,7 @@ Then supply the Service Token using the `doppler-token` input:
 A Doppler Service Account Token allows for a configurable set of permissions to services in your workplace. The `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Token:
 
 ```yaml
-- uses: dopplerhq/secrets-fetch-action@v1.1.2
+- uses: dopplerhq/secrets-fetch-action@v1.1.3
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: dopplerhq/secrets-fetch-action@v1.1.2
+    - uses: dopplerhq/secrets-fetch-action@v1.1.3
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: dopplerhq/secrets-fetch-action@v1.1.2
+    - uses: dopplerhq/secrets-fetch-action@v1.1.3
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
       Inject secrets as environment variables for subsequent steps if set to `true`.
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "doppler-secrets-fetch-github-action",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "description": "GitHub Action to fetch secrets from Doppler's API",
     "author": "Doppler",
     "license": "Apache-2.0",


### PR DESCRIPTION
Release Note: Node 16 is being deprecated in Github Actions: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

See [test run](https://github.com/rgharris/doppler-secrets-fetch-action-test/actions/runs/7836617538).

Todo: 

- [ ] Tag and publish release

Closes #14 
Closes ENG-7523