### PR TITLE
Do not call `setSecret` on any unmasked secrets

### DIFF
--- a/doppler.js
+++ b/doppler.js
@@ -35,7 +35,7 @@ async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
           res.on("data", (data) => (payload += data));
           res.on("end", () => {
             if (res.statusCode === 200) {
-              resolve(JSON.parse(payload));
+              resolve(JSON.parse(payload).secrets);
             } else {
               try {
                 const error = JSON.parse(payload).messages.join(" ");

--- a/doppler.js
+++ b/doppler.js
@@ -6,7 +6,7 @@ import { VERSION } from "./meta.js";
  * @param {string} dopplerToken
  * @param {string | null} [dopplerProject]
  * @param {string | null} [dopplerConfig]
- * @returns {() => Promise<Record<string, string>>}
+ * @returns {() => Promise<Record<string, Record>>}
  */
 async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
   return new Promise(function (resolve, reject) {
@@ -14,7 +14,7 @@ async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
     const authHeader = `Basic ${encodedAuthData}`;
     const userAgent = `secrets-fetch-github-action/${VERSION}`;
 
-    const url = new URL("https://api.doppler.com/v3/configs/config/secrets/download?format=json");
+    const url = new URL("https://api.doppler.com/v3/configs/config/secrets");
     if (dopplerProject && dopplerConfig) {
       url.searchParams.append("project", dopplerProject);
       url.searchParams.append("config", dopplerConfig);
@@ -27,6 +27,7 @@ async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
           headers: {
             Authorization: authHeader,
             "user-agent": userAgent,
+            "accepts": "application/json",
           },
         },
         (res) => {

--- a/index.js
+++ b/index.js
@@ -27,9 +27,11 @@ if (IS_SA_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
 
 const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 
-for (const [key, value] of Object.entries(secrets)) {
+for (const [key, secret] of Object.entries(secrets)) {
+  const value = secret.computed;
+
   core.setOutput(key, value);
-  if (!DOPPLER_META.includes(key)) {
+  if (!DOPPLER_META.includes(key) && secret.computedVisibility !== "unmasked") {
     core.setSecret(value);
   }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,12 @@ const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 for (const [key, secret] of Object.entries(secrets)) {
   const value = secret.computed;
 
+  try {
+    core.info(`Key ${key} has computed value of length ${value.length}, a raw value of length ${(secret.raw || "").length} and is ${secret.computedVisibility} (computed vis) vs ${secret.rawVisibility} (raw vis)`);
+  } catch (e) {
+    core.info(`Error trying to print out debugging info for ${key} ... ${e}`);
+  }
+
   core.setOutput(key, value);
   if (!DOPPLER_META.includes(key) && secret.computedVisibility !== "unmasked") {
     core.setSecret(value);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ if (IS_SA_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
 const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 
 for (const [key, secret] of Object.entries(secrets)) {
-  const value = secret.computed;
+  const value = secret.computed || secret.raw || "";
 
   try {
     core.info(`Key ${key} has computed value of length ${value.length}, a raw value of length ${(secret.raw || "").length} and is ${secret.computedVisibility} (computed vis) vs ${secret.rawVisibility} (raw vis)`);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ if (IS_SA_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
 const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 
 for (const [key, secret] of Object.entries(secrets)) {
-  const value = secret.computed || secret.raw || "";
+  const value = secret.computed || "";
 
   core.setOutput(key, value);
   if (!DOPPLER_META.includes(key) && secret.computedVisibility !== "unmasked") {

--- a/index.js
+++ b/index.js
@@ -30,12 +30,6 @@ const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
 for (const [key, secret] of Object.entries(secrets)) {
   const value = secret.computed || secret.raw || "";
 
-  try {
-    core.info(`Key ${key} has computed value of length ${value.length}, a raw value of length ${(secret.raw || "").length} and is ${secret.computedVisibility} (computed vis) vs ${secret.rawVisibility} (raw vis)`);
-  } catch (e) {
-    core.info(`Error trying to print out debugging info for ${key} ... ${e}`);
-  }
-
   core.setOutput(key, value);
   if (!DOPPLER_META.includes(key) && secret.computedVisibility !== "unmasked") {
     core.setSecret(value);


### PR DESCRIPTION
Right now, every value that's pulled from Doppler is marked as a secret in GitHub Actions, which means any workflow using this action ends up with a ton of unnecessary redactions.

For example, if you have the following Doppler values:

```
NODE_ENV = test
WORKER_COUNT = 3
```

Then *every* output that includes `test` and the number 3 gets redacted, making the output rather difficult to read. Now I'm unable to tell the real difference between Listing and Downloading secrets, but from what I can tell from the [api
docs](https://docs.doppler.com/reference/secrets-list) only List Secrets includes the visibility information, so I had to change how secrets are pulled.

Fixes #16