### PR TITLE
New OIDC auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Ser
 Then supply the Service Token using the `doppler-token` input:
 
 ```yaml
-- uses: dopplerhq/secrets-fetch-action@v1.2.0
+- uses: dopplerhq/secrets-fetch-action@v1.3.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -31,7 +31,7 @@ Then supply the Service Token using the `doppler-token` input:
 A Doppler Service Account Token allows for a configurable set of permissions to services in your workplace. The `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Token:
 
 ```yaml
-- uses: dopplerhq/secrets-fetch-action@v1.2.0
+- uses: dopplerhq/secrets-fetch-action@v1.3.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: dopplerhq/secrets-fetch-action@v1.2.0
+    - uses: dopplerhq/secrets-fetch-action@v1.3.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
   secrets-fetch:
     runs-on: ubuntu-latest
     steps:
-    - uses: dopplerhq/secrets-fetch-action@v1.2.0
+    - uses: dopplerhq/secrets-fetch-action@v1.3.0
       id: doppler
       with:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ This action enables you to fetch Doppler secrets for use in your GitHub Actions.
 
 The action can be configured in two ways:
 
-* Service Token (recommended)
-* Service Account Token with Project and Config
+* Service Token
+* Service Account with Project and Config via either:
+  - Service Account Identity via OIDC (recommended)
+  - Service Account Token
+
 
 ### Service Token
 
-A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to a single config and is recommended due to its limited access scope.
+A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to a single config.
 
 Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Service Tokens (e.g. for a Monorepo), you can prefix the secret name using with application name, e.g. `AUTH_API_DOPPLER_TOKEN`.
 
@@ -26,9 +29,34 @@ Then supply the Service Token using the `doppler-token` input:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
 ```
 
-### Service Account Token
+### Service Account 
 
-A Doppler Service Account Token allows for a configurable set of permissions to services in your workplace. The `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Token:
+A Doppler Service Account allows for a configurable set of permissions to services in your workplace. A project and config must be specified when using a service account. Your workplace must be on the Team or Enterprise plan in order to use service accounts.
+
+#### Service Account Identity via OIDC
+
+[Identities](https://docs.doppler.com/docs/service-account-identities) allow a service account to authenticate to Doppler via OIDC without using a static API token. This method works like the Service Account Token method below but without a static API token.
+
+The `auth-method`, `doppler-identity-id`, `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Identity. The permission `id-token: write` is required so that Doppler can obtain an OIDC token from Github for authentication.
+
+```yaml
+jobs:
+  your-example-job:
+    permissions:
+      id-token: write # required for obtaining the OIDC JWT from Github
+    steps:
+      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+          id: doppler
+          with:
+            auth-method: oidc        
+            doppler-identity-id: <your-service-account-identity-uuid> 
+            doppler-project: auth-api
+            doppler-config: ci-cd
+```
+
+#### Service Account Token
+
+ The `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Token:
 
 ```yaml
 - uses: dopplerhq/secrets-fetch-action@v1.3.0

--- a/README.md
+++ b/README.md
@@ -8,26 +8,10 @@ This action enables you to fetch Doppler secrets for use in your GitHub Actions.
 
 The action can be configured in two ways:
 
-* Service Token
 * Service Account with Project and Config via either:
   - Service Account Identity via OIDC (recommended)
   - Service Account Token
-
-
-### Service Token
-
-A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to a single config.
-
-Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Service Tokens (e.g. for a Monorepo), you can prefix the secret name using with application name, e.g. `AUTH_API_DOPPLER_TOKEN`.
-
-Then supply the Service Token using the `doppler-token` input:
-
-```yaml
-- uses: dopplerhq/secrets-fetch-action@v1.3.0
-      id: doppler
-      with:
-        doppler-token: ${{ secrets.DOPPLER_TOKEN }}
-```
+* Service Token
 
 ### Service Account 
 
@@ -65,6 +49,21 @@ jobs:
         doppler-token: ${{ secrets.DOPPLER_TOKEN }}
         doppler-project: auth-api
         doppler-config: ci-cd
+```
+
+### Service Token
+
+A [Doppler Service Token](https://docs.doppler.com/docs/service-tokens) provides read-only access to a single config.
+
+Create a GitHub repository secret named `DOPPLER_TOKEN` or if using multiple Service Tokens (e.g. for a Monorepo), you can prefix the secret name using with application name, e.g. `AUTH_API_DOPPLER_TOKEN`.
+
+Then supply the Service Token using the `doppler-token` input:
+
+```yaml
+- uses: dopplerhq/secrets-fetch-action@v1.3.0
+      id: doppler
+      with:
+        doppler-token: ${{ secrets.DOPPLER_TOKEN }}
 ```
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: >-
       Identity to use, required when auth-method is "oidc".
     required: false
+  doppler-api-domain:
+    default: "api.doppler.com"
+    required: false
 runs:
   using: 'node20'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,17 @@ branding:
   icon: 'lock'
   color: 'blue'
 inputs:
+  auth-method:
+    description: >- 
+      Auth method to use.
+      - "token" (default): Authenticate with a static API token (`doppler-token`)
+      - "oidc": Authenticate via OIDC. Note that this requires the `id-token: write` permission on the Github job or workflow. See https://docs.doppler.com/docs/service-account-identities
+    default: "token"
   doppler-token:
     description: >-
       Doppler Service Token that grants access to a single Config within a Project. 
       See https://docs.doppler.com/docs/service-tokens
-    required: true
+    required: false
   doppler-project:
     description: >-
       Doppler Project
@@ -20,6 +26,10 @@ inputs:
   inject-env-vars:
     description: >-
       Inject secrets as environment variables for subsequent steps if set to `true`.
+    required: false
+  doppler-identity-id:
+    description: >-
+      Identity to use, required when auth-method is "oidc".
     required: false
 runs:
   using: 'node20'

--- a/doppler.js
+++ b/doppler.js
@@ -6,15 +6,16 @@ import { VERSION } from "./meta.js";
  * @param {string} dopplerToken
  * @param {string | null} [dopplerProject]
  * @param {string | null} [dopplerConfig]
+ * @param {string} apiDomain 
  * @returns {() => Promise<Record<string, Record>>}
  */
-export async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
+export async function fetch(dopplerToken, dopplerProject, dopplerConfig, apiDomain) {
   return new Promise(function (resolve, reject) {
     const encodedAuthData = Buffer.from(`${dopplerToken}:`).toString("base64");
     const authHeader = `Basic ${encodedAuthData}`;
     const userAgent = `secrets-fetch-github-action/${VERSION}`;
 
-    const url = new URL("https://api.doppler.com/v3/configs/config/secrets");
+    const url = new URL(`https://${apiDomain}/v3/configs/config/secrets`);
     if (dopplerProject && dopplerConfig) {
       url.searchParams.append("project", dopplerProject);
       url.searchParams.append("config", dopplerConfig);
@@ -58,13 +59,14 @@ export async function fetch(dopplerToken, dopplerProject, dopplerConfig) {
  * Exchange an OIDC token for a short lived Doppler service account token
  * @param {string} identityId 
  * @param {string} oidcToken 
+ * @param {string} apiDomain 
  * @returns {() => Promise<string>}
  */
-export async function oidcAuth(identityId, oidcToken) {
+export async function oidcAuth(identityId, oidcToken, apiDomain) {
   return new Promise(function (resolve, reject) {
     const userAgent = `secrets-fetch-github-action/${VERSION}`;
 
-    const url = new URL("https://api.doppler.com/v3/auth/oidc");
+    const url = new URL(`https://${apiDomain}/v3/auth/oidc`);
     const body = JSON.stringify({
       identity: identityId,
       token: oidcToken

--- a/doppler.js
+++ b/doppler.js
@@ -7,7 +7,7 @@ import { VERSION } from "./meta.js";
  * @param {string | null} [dopplerProject]
  * @param {string | null} [dopplerConfig]
  * @param {string} apiDomain 
- * @returns {() => Promise<Record<string, Record>>}
+ * @returns {Promise<Record<string, Record>>}
  */
 export async function fetch(dopplerToken, dopplerProject, dopplerConfig, apiDomain) {
   return new Promise(function (resolve, reject) {
@@ -60,7 +60,7 @@ export async function fetch(dopplerToken, dopplerProject, dopplerConfig, apiDoma
  * @param {string} identityId 
  * @param {string} oidcToken 
  * @param {string} apiDomain 
- * @returns {() => Promise<string>}
+ * @returns {Promise<string>}
  */
 export async function oidcAuth(identityId, oidcToken, apiDomain) {
   return new Promise(function (resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -1,18 +1,33 @@
 import core from "@actions/core";
-import fetch from "./doppler.js";
+import { fetch, oidcAuth } from "./doppler.js";
 
 // For local testing
 if (process.env.NODE_ENV === "development" && process.env.DOPPLER_TOKEN) {
+  process.env["INPUT_AUTH-METHOD"] = "token";
   process.env["INPUT_DOPPLER-TOKEN"] = process.env.DOPPLER_TOKEN;
   process.env["INPUT_DOPPLER-PROJECT"] = process.env.DOPPLER_PROJECT;
   process.env["INPUT_DOPPLER-CONFIG"] = process.env.DOPPLER_CONFIG;
 }
 
+const AUTH_METHOD = core.getInput("auth-method");
+let DOPPLER_TOKEN = "";
+
+if (AUTH_METHOD === "oidc") {
+  const DOPPLER_IDENTITY_ID = core.getInput("doppler-identity-id", { required: true });
+  const oidcToken = await core.getIDToken();
+  core.setSecret(oidcToken);
+  DOPPLER_TOKEN = await oidcAuth(DOPPLER_IDENTITY_ID, oidcToken)
+} else if (AUTH_METHOD === "token") {
+  DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
+} else {
+  core.setFailed("Unsupported auth-method");
+  process.exit();
+}
+
 const DOPPLER_META = ["DOPPLER_PROJECT", "DOPPLER_CONFIG", "DOPPLER_ENVIRONMENT"];
-const DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 core.setSecret(DOPPLER_TOKEN);
 
-const IS_SA_TOKEN = DOPPLER_TOKEN.startsWith("dp.sa.");
+const IS_SA_TOKEN = DOPPLER_TOKEN.startsWith("dp.sa.") || DOPPLER_TOKEN.startsWith("dp.said.");
 const IS_PERSONAL_TOKEN = DOPPLER_TOKEN.startsWith("dp.pt.");
 const DOPPLER_PROJECT = (IS_SA_TOKEN || IS_PERSONAL_TOKEN) ? core.getInput("doppler-project") : null;
 const DOPPLER_CONFIG = (IS_SA_TOKEN || IS_PERSONAL_TOKEN) ? core.getInput("doppler-config") : null;

--- a/index.js
+++ b/index.js
@@ -4,19 +4,21 @@ import { fetch, oidcAuth } from "./doppler.js";
 // For local testing
 if (process.env.NODE_ENV === "development" && process.env.DOPPLER_TOKEN) {
   process.env["INPUT_AUTH-METHOD"] = "token";
+  process.env["INPUT_DOPPLER-API-DOMAIN"] = "api.doppler.com";
   process.env["INPUT_DOPPLER-TOKEN"] = process.env.DOPPLER_TOKEN;
   process.env["INPUT_DOPPLER-PROJECT"] = process.env.DOPPLER_PROJECT;
   process.env["INPUT_DOPPLER-CONFIG"] = process.env.DOPPLER_CONFIG;
 }
 
 const AUTH_METHOD = core.getInput("auth-method");
+const API_DOMAIN = core.getInput("doppler-api-domain");
 let DOPPLER_TOKEN = "";
 
 if (AUTH_METHOD === "oidc") {
   const DOPPLER_IDENTITY_ID = core.getInput("doppler-identity-id", { required: true });
   const oidcToken = await core.getIDToken();
   core.setSecret(oidcToken);
-  DOPPLER_TOKEN = await oidcAuth(DOPPLER_IDENTITY_ID, oidcToken)
+  DOPPLER_TOKEN = await oidcAuth(DOPPLER_IDENTITY_ID, oidcToken, API_DOMAIN);
 } else if (AUTH_METHOD === "token") {
   DOPPLER_TOKEN = core.getInput("doppler-token", { required: true });
 } else {
@@ -40,7 +42,7 @@ if (IS_SA_TOKEN && !(DOPPLER_PROJECT && DOPPLER_CONFIG)) {
   process.exit();
 }
 
-const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG);
+const secrets = await fetch(DOPPLER_TOKEN, DOPPLER_PROJECT, DOPPLER_CONFIG, API_DOMAIN);
 
 for (const [key, secret] of Object.entries(secrets)) {
   const value = secret.computed || "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.3",
+    "version": "1.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "doppler-secrets-fetch-github-action",
-            "version": "1.1.3",
+            "version": "1.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.3",
+    "version": "1.3.0",
     "description": "GitHub Action to fetch secrets from Doppler's API",
     "author": "Doppler",
     "license": "Apache-2.0",


### PR DESCRIPTION
This depends on yet to be released API changes and **is not ready to be merged yet**. This has been tested with the unpublished API changes via the new `doppler-api-domain` option. 

Release Note: Add OIDC support to the Github Secrets Fetch Action. This allows the action to retrieve secrets from a Doppler service account by authenticating via identity auth.

Closes ENG-8513

Example usages:
```yml
name: Doppler secrets from outputs

on: [push]

jobs:
  secrets-fetch-sa-oidc:
    runs-on: ubuntu-latest
    permissions:
      id-token: write # required for obtaining the OIDC JWT from Github
    steps:
    - uses: dopplerhq/secrets-fetch-action@rgharris/oidc # update to use @v1.3.0 after launch
      id: doppler
      with:
        auth-method: oidc        
        doppler-identity-id: 78efd55a-a93c-4415-8078-7db6a588ba73
        doppler-project: example-project
        doppler-config: dev
        doppler-api-domain: your-custom-local-domain # for local testing only
    - run: echo "DOPPLER_PROJECT is ${{ steps.doppler.outputs.DOPPLER_PROJECT }} (Doppler meta environment variables are unmasked)"
    - run: echo "ANEWONE is ${{ steps.doppler.outputs.ANEWONE }} (secret masked output)"

  secrets-fetch-sa-token:
    runs-on: ubuntu-latest
    steps:
    - uses: dopplerhq/secrets-fetch-action@rgharris/oidc # update to use @v1.3.0 after launch
      id: doppler
      with:
        doppler-token: ${{ secrets.DOPPLER_SA_TOKEN }}
        doppler-project: example-project
        doppler-config: dev
        doppler-api-domain: your-custom-local-domain # for local testing only
    - run: echo "DOPPLER_PROJECT is ${{ steps.doppler.outputs.DOPPLER_PROJECT }} (Doppler meta environment variables are unmasked)"
    - run: echo "ANEWONE is ${{ steps.doppler.outputs.ANEWONE }} (secret masked output)"

  secrets-fetch-service-token:
    runs-on: ubuntu-latest
    steps:
    - uses: dopplerhq/secrets-fetch-action@rgharris/oidc # update to use @v1.3.0 after launch
      id: doppler
      with:
        doppler-token: ${{ secrets.DOPPLER_SERVICE_TOKEN }}
        doppler-api-domain: your-custom-local-domain # for local testing only
    - run: echo "DOPPLER_PROJECT is ${{ steps.doppler.outputs.DOPPLER_PROJECT }} (Doppler meta environment variables are unmasked)"
    - run: echo "ANEWONE is ${{ steps.doppler.outputs.ANEWONE }} (secret masked output)"

```
